### PR TITLE
Get profile name from SSID in Windows

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+	"node" : true,
+	"esversion": 6
+}

--- a/lib/win.js
+++ b/lib/win.js
@@ -2,19 +2,37 @@
 const execa = require('execa');
 
 module.exports = ssid => {
+	// Assumes only one connected WLAN interface, which is likely
 	const cmd = 'netsh';
-	const args = ['wlan', 'show', 'profile', `name=${ssid}`, 'key=clear'];
+	const args = ['wlan', 'show', 'profile', 'name=*'];
 
 	return execa.stdout(cmd, args).then(stdout => {
-		let ret;
+		let profile;
 
-		ret = /^\s*Key Content\s*: (.+)\s*$/gm.exec(stdout);
-		ret = ret && ret.length ? ret[1] : null;
+		// Get profile for our SSID
+		let re = new RegExp('(?:Name\\s+: "?)(.+?$)(?:[\\s\\S][^=]*?(?=\\n.*?"' + ssid + '"))', "gm");
+		profile = re.exec(stdout)[1];
+		profile = profile && profile.length ? profile : null;
 
-		if (!ret) {
-			throw new Error('Could not get password');
+		if (!profile) {
+			throw new Error('Could not get profile name');
 		}
 
-		return ret;
+		return profile;
+	})
+	.then(function(profile) {
+		const args = ['wlan', 'show', 'profile', `name=${profile}`, 'key=clear'];
+		return execa.stdout(cmd, args).then(stdout => {
+			let ret;
+
+			ret = /^\s*Key Content\s*: (.+)\s*$/gm.exec(stdout);
+			ret = ret && ret.length ? ret[1] : null;
+
+			if (!ret) {
+				throw new Error('Could not get password');
+			}
+
+			return ret;
+		});
 	});
 };


### PR DESCRIPTION
SSID and profile name don't always coincide. Users can rename saved WiFi networks to something more convenient to them. This gets the correct string expected by the `netsh wlan show profile` command.